### PR TITLE
Fixed Error in Edge creation

### DIFF
--- a/src/vasco/callgraph/CallGraphTransformer.java
+++ b/src/vasco/callgraph/CallGraphTransformer.java
@@ -82,8 +82,17 @@ public class CallGraphTransformer extends SceneTransformer {
 			for (final SootMethod targetMethod : targets.keySet()) {
 				final Context<SootMethod, Unit, PointsToGraph> targetContext = targets.get(targetMethod);
 
+				Kind K;
+				if(stmt instanceof InvokeExpr)
+				{
+					K=Edge.ieToKind((InvokeExpr)stmt);
+				}
+				else
+				{
+					K=Kind.INVALID;
+				}
 				// The context-insensitive edge
-				Edge cgEdge = new Edge(sourceMethod, (Stmt) stmt, targetMethod);
+				Edge cgEdge = new Edge(sourceMethod, (Stmt) stmt, targetMethod,K);
 				
 				// Add it to the context-insensitive call-graph
 				callGraph.addEdge(cgEdge);


### PR DESCRIPTION
VASCO's PointsToAnalysis generates callsites that does not invoke any function. Thus while creating CallGraph edge program does not find callsite as Invoke Expression and throws exception. So changes suggests that if there is  presence of Invoke Expression then only edge will be created.